### PR TITLE
Add GitHub auth for private repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,12 @@ need to expose coming soon).
 
 Nearly every step of the changelog generation process is hookable via `config/changelog.js`.
 
+## Github Private Repos
+
+If you want to use github private repos set your github token with the following environment variable
+ 
+`GITHUB_TOKEN=123abc`
+
 ## Contributing
 
  - Open an Issue for discussion first if you're unsure a feature/fix is wanted.

--- a/lib/ext/get-env-var.js
+++ b/lib/ext/get-env-var.js
@@ -1,0 +1,11 @@
+/* jshint node: true */
+
+module.exports = function(name, defaultValue) {
+  if (process.env[name]) {
+    return process.env[name];
+  } else if (defaultValue !== undefined) {
+    return defaultValue;
+  } else {
+    throw new Error('Expected environment variable `' + name + '` to be set but it was not.');
+  }
+};

--- a/lib/helpers/git/github/compare-commits.js
+++ b/lib/helpers/git/github/compare-commits.js
@@ -1,8 +1,19 @@
 // jshint node:true
 
 var Promise = require('../../../ext/promise');  // jshint ignore:line
+var getEnvVar = require('../../../ext/get-env-var');  // jshint ignore:line
 var GitHubApi = require('github');
 var github = new GitHubApi({ version: '3.0.0' });
+
+var githubToken = getEnvVar('GITHUB_TOKEN', null);
+
+if (githubToken) {
+  github.authenticate({
+    type: 'oauth',
+    token: githubToken
+  });
+}
+
 var compareCommits = Promise.denodeify(github.repos.compareCommits);
 var massageGithubCommits = require('./massage-commits');
 


### PR DESCRIPTION
You can now use private repos by setting the GITHUB_TOKEN environment variable while running `ember changelog`
