### PR TITLE
Added the date to the changelog title

### DIFF
--- a/lib/helpers/create-updated-changelog.js
+++ b/lib/helpers/create-updated-changelog.js
@@ -50,7 +50,7 @@ function insertLines(existingLines, offset, linesToInsert) {
 
 function generateChanges(config, groups) {
   var todaysDate = moment().format('MMMM Do, YYYY');
-  var lines = ['## ' + config.versions.next + '(' + todaysDate + ')']
+  var lines = ['## ' + config.versions.next + ' (' + todaysDate + ')']
     .concat(config.hooks.beforeChanges ? ['', config.hooks.beforeChanges()] : [])
     .concat(changesForGroups(groups))
     .concat(config.hooks.afterChanges ? ['', config.hooks.afterChanges(), ''] : ['']);

--- a/lib/helpers/create-updated-changelog.js
+++ b/lib/helpers/create-updated-changelog.js
@@ -2,6 +2,7 @@
 var fs = require('fs');
 var path = require('path');
 var chalk = require('chalk');
+var moment = require('moment');
 
 module.exports = function(config, groups) {
   var changelogPath = path.join(config.project.root, 'CHANGELOG.md');
@@ -48,7 +49,8 @@ function insertLines(existingLines, offset, linesToInsert) {
 }
 
 function generateChanges(config, groups) {
-  var lines = ['## ' + config.versions.next]
+  var todaysDate = moment().format('MMMM D, YYYY');
+  var lines = ['## ' + config.versions.next + '(' + todaysDate + ')']
     .concat(config.hooks.beforeChanges ? ['', config.hooks.beforeChanges()] : [])
     .concat(changesForGroups(groups))
     .concat(config.hooks.afterChanges ? ['', config.hooks.afterChanges(), ''] : ['']);

--- a/lib/helpers/create-updated-changelog.js
+++ b/lib/helpers/create-updated-changelog.js
@@ -49,7 +49,7 @@ function insertLines(existingLines, offset, linesToInsert) {
 }
 
 function generateChanges(config, groups) {
-  var todaysDate = moment().format('MMMM D, YYYY');
+  var todaysDate = moment().format('MMMM Do, YYYY');
   var lines = ['## ' + config.versions.next + '(' + todaysDate + ')']
     .concat(config.hooks.beforeChanges ? ['', config.hooks.beforeChanges()] : [])
     .concat(changesForGroups(groups))

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "ember-cli-babel": "^5.1.6",
     "github": "^0.2.4",
     "jsonfile": "^2.2.3",
+    "moment": "^2.13.0",
     "multiline": "^1.0.2",
     "object-assign": "^4.0.1",
     "rsvp": "^3.1.0",


### PR DESCRIPTION
Added moment.js to help with formatting the date

New heading format

`1.0.0 (May 2nd, 2016)`

Influenced by: https://github.com/emberjs/ember.js/blob/master/CHANGELOG.md#260-beta3-may-02-2016
