### PR TITLE
Ember style & custom ignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@
 /config/ember-try.js
 /dist
 /tests
+/node-tests
 /tmp
 **/.gitkeep
 .bowerrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ install:
 
 script:
   - ember try $EMBER_TRY_SCENARIO test
+  - npm run-script test-node

--- a/lib/helpers/default-commit-filter.js
+++ b/lib/helpers/default-commit-filter.js
@@ -2,14 +2,15 @@
 
 module.exports = function defaultCommitFilter(commit, config) {
   var isComplete;
+
   if (config.style === 'ember') {
     isComplete = commit.isMerge || commit.isRevert || commit.isBreaking || commit.type;
-    return isComplete && ['task', 'chore'].indexOf(commit.type.toLowerCase()) === -1;
+    return isComplete && (config.ignore || ['TASK', 'CHORE']).indexOf(commit.type) === -1;
   } else if (config.style === 'angular') {
     isComplete = commit.isMerge || commit.isRevert || (commit.type && commit.scope && commit.title);
-    return isComplete && ['task', 'chore'].indexOf(commit.type) === -1;
+    return isComplete && (config.ignore || ['task', 'chore']).indexOf(commit.type) === -1;
   } else {
     isComplete = commit.isMerge || commit.isRevert || (commit.type && commit.scope && commit.title);
-    return isComplete && ['task', 'chore'].indexOf(commit.type) === -1;
+    return isComplete && (config.ignore || ['task', 'chore']).indexOf(commit.type) === -1;
   }
 };

--- a/lib/helpers/default-commit-group-sort.js
+++ b/lib/helpers/default-commit-group-sort.js
@@ -1,16 +1,23 @@
 // jshint node:true
 
-module.exports = function defaultCommitGroupSort(commits) {
+module.exports = function defaultCommitGroupSort(commits, config) {
   var merges = commits.filter(function(commit) {
     return commit.isMerge;
   });
+
   var other = commits.filter(function(commit) {
-    return !commit.isMerge && (commit.isRevert || (commit.type && commit.scope && commit.title));
+    var isValidCommit = commit.type && commit.title;
+
+    if (config.style !== 'ember') {
+      isValidCommit = isValidCommit && commit.scope;
+    }
+
+    return !commit.isMerge && (commit.isRevert || isValidCommit);
   });
 
   merges.sort(function(a, b) {
-      return a.number > b.number;
-    });
+    return a.number > b.number;
+  });
 
   other.reverse();
 

--- a/lib/helpers/git/parse/ember-style.js
+++ b/lib/helpers/git/parse/ember-style.js
@@ -56,10 +56,10 @@ function parseMessage(message) {
   if (endTitleIndex <= 0) {
     return {};
   }
-  var preTitle = message.substr(0, endTitleIndex);
+  var preTitle = message.substr(0, endTitleIndex + 1);
   var postTitle = message.substr(endTitleIndex + 1);
 
-  var preTitleExp = /^\[([a-zA-Z]+\s?)([a-zA-Z]+)?\]/;
+  var preTitleExp = /^\[([a-zA-Z]+)\s?([a-zA-Z]+)?\]/;
   var preTitleParts = preTitle.match(preTitleExp);
 
   if (!preTitleParts) {
@@ -67,7 +67,7 @@ function parseMessage(message) {
   }
 
   var type = preTitleParts[1].toUpperCase();
-
+  
   return {
     type: type,
     typeIsStandard: types.indexOf(type) !== -1,

--- a/lib/tasks/changelog.js
+++ b/lib/tasks/changelog.js
@@ -48,7 +48,7 @@ module.exports = function() {
           if (config.hooks.groupSort && typeof config.hooks.groupSort === 'function') {
             return config.hooks.groupSort(commits);
           }
-          return defaultCommitGroupSort(commits);
+          return defaultCommitGroupSort(commits, config);
         })
 
         // format commits

--- a/node-tests/unit/helpers/default-commit-filter-test.js
+++ b/node-tests/unit/helpers/default-commit-filter-test.js
@@ -1,0 +1,174 @@
+/* jshint node:true */
+
+'use strict';
+
+var expect = require('chai').expect;
+var defaultCommitFilter = require('../../../lib/helpers/default-commit-filter');
+
+describe('default commit filter', function () {
+
+  /* ember style */
+
+  it('should correctly include valid ember commit', function() {
+
+    var commit = {
+      type: 'DOC',
+      scope: 'beta',
+      isStandard: true,
+      title: 'update documentation'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'ember'});
+    expect(isCommitIncluded).to.be.true;
+  });
+
+  it('should correctly ignore defaultly excluded ember commit types', function() {
+
+    var commit = {
+      type: 'TASK',
+      scope: 'beta',
+      isStandard: true,
+      title: 'some task'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'ember'});
+    expect(isCommitIncluded).to.be.false;
+
+    commit.type = 'CHORE';
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'ember'});
+    expect(isCommitIncluded).to.be.false;
+  });
+
+  it('should correctly ignore custom excluded ember commit types', function() {
+
+    var commit = {
+      type: 'TASK',
+      scope: 'beta',
+      isStandard: true,
+      title: 'some task'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'ember', ignore: []});
+    expect(isCommitIncluded).to.be.true;
+
+    commit.type = 'DOC';
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'ember', ignore: ['DOC']});
+    expect(isCommitIncluded).to.be.false;
+
+    commit.type = 'TOOLING';
+    commit.isStandard = false;
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'ember', ignore: ['DOC', 'TOOLING']});
+    expect(isCommitIncluded).to.be.false;
+  });
+
+  /* angular style */
+
+  it('should correctly include valid angular commit', function() {
+
+    var commit = {
+      type: 'docs',
+      scope: 'beta',
+      isStandard: true,
+      title: 'update documentation'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'angular'});
+
+    expect(isCommitIncluded).to.be.true;
+  });
+
+  it('should correctly ignore defaultly excluded angular commit types', function() {
+
+    var commit = {
+      type: 'task',
+      scope: 'beta',
+      isStandard: true,
+      title: 'some task'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'angular'});
+    expect(isCommitIncluded).to.be.false;
+
+    commit.type = 'chore';
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'angular'});
+    expect(isCommitIncluded).to.be.false;
+  });
+
+  it('should correctly ignore custom excluded angular commit types', function() {
+
+    var commit = {
+      type: 'task',
+      scope: 'beta',
+      isStandard: true,
+      title: 'some task'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'angular', ignore: []});
+    expect(isCommitIncluded).to.be.true;
+
+    commit.type = 'docs';
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'angular', ignore: ['docs']});
+    expect(isCommitIncluded).to.be.false;
+
+    commit.type = 'tooling';
+    commit.isStandard = false;
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'angular', ignore: ['doc', 'tooling']});
+    expect(isCommitIncluded).to.be.false;
+  });
+
+  /* jquery style */
+
+  it('should correctly include valid angular commit', function() {
+
+    var commit = {
+      type: 'docs',
+      scope: 'beta',
+      isStandard: true,
+      title: 'update documentation'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'jquery'});
+
+    expect(isCommitIncluded).to.be.true;
+  });
+
+  it('should correctly ignore excluded defaultly jquery commit types', function() {
+
+    var commit = {
+      type: 'task',
+      scope: 'beta',
+      isStandard: true,
+      title: 'some task'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'jquery'});
+    expect(isCommitIncluded).to.be.false;
+
+    commit.type = 'chore';
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'jquery'});
+    expect(isCommitIncluded).to.be.false;
+  });
+
+  it('should correctly ignore custom excluded jquery commit types', function() {
+
+    var commit = {
+      type: 'task',
+      scope: 'beta',
+      isStandard: true,
+      title: 'some task'
+    }; 
+
+    var isCommitIncluded = defaultCommitFilter(commit, {style: 'jquery', ignore: []});
+    expect(isCommitIncluded).to.be.true;
+
+    commit.type = 'docs';
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'jquery', ignore: ['docs']});
+    expect(isCommitIncluded).to.be.false;
+
+    commit.type = 'tooling';
+    commit.isStandard = false;
+    isCommitIncluded = defaultCommitFilter(commit, {style: 'jquery', ignore: ['doc', 'tooling']});
+    expect(isCommitIncluded).to.be.false;
+  });
+ 
+});

--- a/node-tests/unit/helpers/default-commit-group-sort-test.js
+++ b/node-tests/unit/helpers/default-commit-group-sort-test.js
@@ -1,0 +1,49 @@
+/* jshint node:true */
+
+'use strict';
+
+var expect = require('chai').expect;
+var defaultCommitGroupSort = require('../../../lib/helpers/default-commit-group-sort');
+
+describe('default commit group sort', function () {
+  it('should correctly filter other ember commit', function() {
+
+    var commits = [{
+      type: 'DOC',
+      scope: 'beta',
+      isStandard: true,
+      title: 'update documentation'
+    }, {
+      type: 'DOC',
+      scope: undefined,
+      isStandard: true,
+      title: 'update documentation'
+    }]; 
+
+    var orderedCommits = defaultCommitGroupSort(commits, {style: 'ember'});
+
+    expect(orderedCommits).to.have.lengthOf(2);
+    expect(orderedCommits[1].commits).to.have.lengthOf(2);
+  });
+
+  it('should correctly filter other angular commits', function() {
+
+    var commits = [{
+      type: 'docs',
+      scope: 'beta',
+      isStandard: true,
+      title: 'update documentation'
+    }, {
+      type: 'docs',
+      scope: undefined,
+      isStandard: true,
+      title: 'update documentation'
+    }]; 
+
+    var orderedCommits = defaultCommitGroupSort(commits, {style: 'angular'});
+
+    expect(orderedCommits).to.have.lengthOf(2);
+    expect(orderedCommits[1].commits).to.have.lengthOf(1);
+  });
+  
+});

--- a/node-tests/unit/helpers/git/parse/ember-style-test.js
+++ b/node-tests/unit/helpers/git/parse/ember-style-test.js
@@ -1,0 +1,36 @@
+/* jshint node:true */
+
+'use strict';
+
+var expect = require('chai').expect;
+var parseCommit = require('../../../../../lib/helpers/git/parse/ember-style');
+
+describe('ember parse', function () {
+  it('should correctly parse standard commit', function() {
+    var parsed = parseCommit({ title: "[DOC beta] Update documentation"});
+
+    expect(parsed.type).to.equal("DOC");
+    expect(parsed.typeIsStandard).to.be.true;
+    expect(parsed.scope).to.be.equal("beta");
+    expect(parsed.title).to.be.equal("Update documentation");
+  });
+
+  it('should correctly parse non standard commit', function() {
+    var parsed = parseCommit({ title: "[UNKNOWN beta] Update unknown"});
+
+    expect(parsed.type).to.equal("UNKNOWN");
+    expect(parsed.typeIsStandard).to.be.false;
+    expect(parsed.scope).to.be.equal("beta");
+    expect(parsed.title).to.be.equal("Update unknown");
+  });
+
+
+  it('should correctly parse non scoped commit', function() {
+    var parsed = parseCommit({ title: "[DOC] Update documentation"});
+
+    expect(parsed.type).to.equal("DOC");
+    expect(parsed.typeIsStandard).to.be.true;
+    expect(parsed.scope).to.be.undefined;
+    expect(parsed.title).to.be.equal("Update documentation");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:testall",
+    "test-node": "mocha node-tests --recursive"
   },
   "repository": "https://github.com/runspired/ember-cli-changelog.git",
   "engines": {
@@ -19,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "chai": "^3.5.0",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.5.0",
     "ember-cli-app-version": "^1.0.0",
@@ -36,7 +38,8 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
-    "loader.js": "^4.0.1"
+    "loader.js": "^4.0.1",
+    "mocha": "^2.5.3"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Hi,

Unless if I am wrong, I found some issues using ember style regarding scopes:
1. Because of a bad index [here](https://github.com/runspired/ember-cli-changelog/compare/develop...bmeurant:ember-style?expand=1#diff-75c23ba9ae94bb92f778e6677ad5ef11R59) and an error in regex [here](https://github.com/runspired/ember-cli-changelog/compare/develop...bmeurant:ember-style?expand=1#diff-75c23ba9ae94bb92f778e6677ad5ef11R62), type and scope were not properly parsed
2. The filter [here](https://github.com/runspired/ember-cli-changelog/compare/develop...bmeurant:ember-style?expand=1#diff-054d0de5eb5b274ac6ce2c47aae0631aL8) was expecting a non null scope to consider the commit valid

These issues made mandatory to provide a scope like `[DOC beta] smthg` but ember style considers `[DOC] smthg` valid. And, imho, scopes in ember style are overkill for most small addons. This PR fixes these points.

This PR also implements the ability fo users to provide a custom array of ignored commit types. This will allow to override default `['task', 'chore']` value.

I also added mocha / chai tooling for testing libs and provided tests in relation with these changes.

I made some small unitary commit so you can pick the ones you want ... I can rebase / squash or even split this PR with another.

Let me know ...
