### PR TITLE
Set angular as default in blueprint

### DIFF
--- a/blueprints/ember-cli-changelog/files/config/changelog.js
+++ b/blueprints/ember-cli-changelog/files/config/changelog.js
@@ -6,7 +6,7 @@ module.exports = {
   // ember style guide: https://github.com/emberjs/ember.js/blob/master/CONTRIBUTING.md#commit-tagging
   // angular style guide: https://github.com/angular/angular.js/blob/v1.4.8/CONTRIBUTING.md#commit
   // jquery style guide: https://contribute.jquery.org/commits-and-pull-requests/#commit-guidelines
-  style: 'ember', // 'angular' 'jquery'
+  style: 'angular', // 'ember' 'jquery'
 
   head: 'master',
   base: '-last', // a branch or tag name, `-last` defaults to the version in package.json


### PR DESCRIPTION
@runspired after some heavy use of this addon, it seems like you were right about `angular` being the more superior style. I've had a much better experience once I started using it instead of `ember`. 
